### PR TITLE
mock memcache extends real memcache class

### DIFF
--- a/MockMemcache.php
+++ b/MockMemcache.php
@@ -7,7 +7,7 @@ namespace SM\MemcacheBundle;
  * @author Tarjei Huse (tarjei@scanmine.com) http://www.kraken.no
  */
 
-class MockMemcache {
+class MockMemcache extends \Memcached {
 
     private $_cache = array();
     private $_cacheVars = array();


### PR DESCRIPTION
Hello,

This PR makes `MockMemcache` class extend real `Memcached` class in order to be safely substituted in injections with strong typing. Consider following simple example:

``` php
class ClassUsingMemcached 
{
  private $memcached;

  public __construct(Memcached $memcached) 
  {
    $this->memcached = $memcached;
  }
}
```
